### PR TITLE
Remove top-layout layout modifiers

### DIFF
--- a/src/layout/index.scss
+++ b/src/layout/index.scss
@@ -6,11 +6,3 @@
 @use "namespace";
 @use "section";
 @use "static";
-
-@include static.declare(layout, immediate) {
-  @include static.declare(section-padding, none) {
-    .#{namespace.use-prefix(section)} {
-      @include section.padding((top: 0, bottom: 0));
-    }
-  }
-}


### PR DESCRIPTION
This pull request removes the top-level layout modifiers controlling descendant layout elements. That is, at least for now, out of the scope of Tidgrid's philosophy and the domain for which Tidgrid tries to provide a solution.